### PR TITLE
회원가입 스텝 ref, state사용해서 개선 (refactor/signup-step-validation)

### DIFF
--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -3,11 +3,10 @@
 import munto from "@/assets/mt-question.png";
 import { OnboardingNavbar, StepContainer } from "@/components/shared";
 import { Bubble } from "@/components/ui";
-import { useForm, useFunnel } from "@/hooks";
+import { FormProvider, useForm, useFunnel } from "@/hooks";
 import { DEFAULT_FORM, QUESTIONS, SIGN_UP_STEPS } from "@/lib/const";
 import { SignUpForm, SignUpStep } from "@/type";
 import Image from "next/image";
-import { useRef, useState } from "react";
 
 export default function SignUp() {
   const { currentStep, currentStepIndex, goToPreviousStep, goToNextStep } =
@@ -15,17 +14,12 @@ export default function SignUp() {
 
   const { form, handleChange } = useForm<SignUpForm>(DEFAULT_FORM);
 
-  const stepFormRef = useRef<HTMLFormElement>(null);
-  const [isFormValid, setIsFormValid] = useState(false);
-
   return (
-    <>
+    <FormProvider>
       <OnboardingNavbar
         stepIndex={currentStepIndex}
         totalSteps={SIGN_UP_STEPS.length}
         goToPreviousStep={goToPreviousStep}
-        formRef={stepFormRef}
-        isFormValid={isFormValid}
       />
       <Bubble speech={QUESTIONS[currentStep]} />
       <Image src={munto} alt="munto" />
@@ -34,9 +28,7 @@ export default function SignUp() {
         form={form}
         handleChange={handleChange}
         goToNextStep={goToNextStep}
-        formRef={stepFormRef}
-        setIsFormValid={setIsFormValid}
       />
-    </>
+    </FormProvider>
   );
 }

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -7,6 +7,7 @@ import { useForm, useFunnel } from "@/hooks";
 import { DEFAULT_FORM, QUESTIONS, SIGN_UP_STEPS } from "@/lib/const";
 import { SignUpForm, SignUpStep } from "@/type";
 import Image from "next/image";
+import { useRef, useState } from "react";
 
 export default function SignUp() {
   const { currentStep, currentStepIndex, goToPreviousStep, goToNextStep } =
@@ -14,12 +15,17 @@ export default function SignUp() {
 
   const { form, handleChange } = useForm<SignUpForm>(DEFAULT_FORM);
 
+  const stepFormRef = useRef<HTMLFormElement>(null);
+  const [isFormValid, setIsFormValid] = useState(false);
+
   return (
     <>
       <OnboardingNavbar
         stepIndex={currentStepIndex}
         totalSteps={SIGN_UP_STEPS.length}
         goToPreviousStep={goToPreviousStep}
+        formRef={stepFormRef}
+        isFormValid={isFormValid}
       />
       <Bubble speech={QUESTIONS[currentStep]} />
       <Image src={munto} alt="munto" />
@@ -28,6 +34,8 @@ export default function SignUp() {
         form={form}
         handleChange={handleChange}
         goToNextStep={goToNextStep}
+        formRef={stepFormRef}
+        setIsFormValid={setIsFormValid}
       />
     </>
   );

--- a/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
+++ b/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
@@ -1,5 +1,4 @@
 import { BackButton, ForwardButton, ProgressBar } from "@/components/ui";
-import { SIGN_UP_STEPS } from "@/lib/const";
 import { submitIdForm } from "@/lib/utils";
 import styles from "./styles.module.scss";
 
@@ -7,9 +6,17 @@ interface Props {
   stepIndex: number;
   totalSteps: number;
   goToPreviousStep: () => void;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isFormValid: boolean;
 }
 
-export function OnboardingNavbar({ stepIndex, totalSteps, goToPreviousStep }: Readonly<Props>) {
+export function OnboardingNavbar({
+  stepIndex,
+  totalSteps,
+  goToPreviousStep,
+  formRef,
+  isFormValid,
+}: Readonly<Props>) {
   const progress = stepIndex + 1;
 
   return (
@@ -17,7 +24,7 @@ export function OnboardingNavbar({ stepIndex, totalSteps, goToPreviousStep }: Re
       <div className={styles["back-forward-container"]}>
         {stepIndex === 0 && <div />}
         {stepIndex > 0 && <BackButton onClick={goToPreviousStep} />}
-        <ForwardButton onClick={() => submitIdForm(SIGN_UP_STEPS[stepIndex])} />
+        <ForwardButton onClick={() => submitIdForm(formRef)} disabled={!isFormValid} />
       </div>
       <ProgressBar
         className={styles["progress-bar"]}

--- a/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
+++ b/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
@@ -3,11 +3,11 @@ import { useFormContext } from "@/hooks";
 import { submitRefForm } from "@/lib/utils";
 import styles from "./styles.module.scss";
 
-interface Props {
+type Props = {
   stepIndex: number;
   totalSteps: number;
   goToPreviousStep: () => void;
-}
+};
 
 export function OnboardingNavbar({ stepIndex, totalSteps, goToPreviousStep }: Readonly<Props>) {
   const { currentStepFormRef, isFormValid } = useFormContext();

--- a/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
+++ b/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
@@ -1,5 +1,5 @@
 import { BackButton, ForwardButton, ProgressBar } from "@/components/ui";
-import { submitIdForm } from "@/lib/utils";
+import { submitRefForm } from "@/lib/utils";
 import styles from "./styles.module.scss";
 
 interface Props {
@@ -24,7 +24,7 @@ export function OnboardingNavbar({
       <div className={styles["back-forward-container"]}>
         {stepIndex === 0 && <div />}
         {stepIndex > 0 && <BackButton onClick={goToPreviousStep} />}
-        <ForwardButton onClick={() => submitIdForm(formRef)} disabled={!isFormValid} />
+        <ForwardButton onClick={() => submitRefForm(formRef)} disabled={!isFormValid} />
       </div>
       <ProgressBar
         className={styles["progress-bar"]}

--- a/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
+++ b/src/components/shared/onboarding-navbar/onboarding-navbar.tsx
@@ -1,4 +1,5 @@
 import { BackButton, ForwardButton, ProgressBar } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { submitRefForm } from "@/lib/utils";
 import styles from "./styles.module.scss";
 
@@ -6,17 +7,10 @@ interface Props {
   stepIndex: number;
   totalSteps: number;
   goToPreviousStep: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  isFormValid: boolean;
 }
 
-export function OnboardingNavbar({
-  stepIndex,
-  totalSteps,
-  goToPreviousStep,
-  formRef,
-  isFormValid,
-}: Readonly<Props>) {
+export function OnboardingNavbar({ stepIndex, totalSteps, goToPreviousStep }: Readonly<Props>) {
+  const { currentStepFormRef, isFormValid } = useFormContext();
   const progress = stepIndex + 1;
 
   return (
@@ -24,7 +18,7 @@ export function OnboardingNavbar({
       <div className={styles["back-forward-container"]}>
         {stepIndex === 0 && <div />}
         {stepIndex > 0 && <BackButton onClick={goToPreviousStep} />}
-        <ForwardButton onClick={() => submitRefForm(formRef)} disabled={!isFormValid} />
+        <ForwardButton onClick={() => submitRefForm(currentStepFormRef)} disabled={!isFormValid} />
       </div>
       <ProgressBar
         className={styles["progress-bar"]}

--- a/src/components/shared/sign-up-step/step-container.tsx
+++ b/src/components/shared/sign-up-step/step-container.tsx
@@ -1,4 +1,5 @@
 import { SignUpForm, SignUpStep } from "@/type";
+import { memo } from "react";
 import {
   SelectGenderStep,
   SelectMbtiStep,
@@ -7,14 +8,23 @@ import {
   TypeNameStep,
 } from "./step";
 
-type Props = {
+interface Props {
   currentStep: SignUpStep;
   form: SignUpForm;
   handleChange: (key: keyof SignUpForm, value: SignUpForm[keyof SignUpForm]) => void;
   goToNextStep: () => void;
-};
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
+}
 
-export function StepContainer({ currentStep, form, handleChange, goToNextStep }: Readonly<Props>) {
+function StepContainerBase({
+  currentStep,
+  form,
+  handleChange,
+  goToNextStep,
+  formRef,
+  setIsFormValid,
+}: Readonly<Props>) {
   switch (currentStep) {
     case "이름 입력":
       return (
@@ -22,11 +32,19 @@ export function StepContainer({ currentStep, form, handleChange, goToNextStep }:
           value={form.name}
           onSubmit={(value) => handleChange("name", value)}
           onNext={goToNextStep}
+          formRef={formRef}
+          setIsFormValid={setIsFormValid}
         />
       );
     case "성별 선택":
       return (
-        <SelectGenderStep gender={form.gender} handleChange={handleChange} onNext={goToNextStep} />
+        <SelectGenderStep
+          gender={form.gender}
+          handleChange={handleChange}
+          onNext={goToNextStep}
+          formRef={formRef}
+          setIsFormValid={setIsFormValid}
+        />
       );
     case "생년월일 입력":
       return (
@@ -37,6 +55,8 @@ export function StepContainer({ currentStep, form, handleChange, goToNextStep }:
             handleChange("calendarType", value.calendarType);
           }}
           onNext={goToNextStep}
+          formRef={formRef}
+          setIsFormValid={setIsFormValid}
         />
       );
     case "출생시간 입력":
@@ -45,11 +65,21 @@ export function StepContainer({ currentStep, form, handleChange, goToNextStep }:
           value={form.birthTime}
           onSubmit={(value) => handleChange("birthTime", value)}
           onNext={goToNextStep}
+          formRef={formRef}
+          setIsFormValid={setIsFormValid}
         />
       );
     case "MBTI 입력":
-      return <SelectMbtiStep handleChange={handleChange} />;
+      return (
+        <SelectMbtiStep
+          handleChange={handleChange}
+          formRef={formRef}
+          setIsFormValid={setIsFormValid}
+        />
+      );
     default:
       return null;
   }
 }
+
+export const StepContainer = memo(StepContainerBase);

--- a/src/components/shared/sign-up-step/step-container.tsx
+++ b/src/components/shared/sign-up-step/step-container.tsx
@@ -13,18 +13,9 @@ interface Props {
   form: SignUpForm;
   handleChange: (key: keyof SignUpForm, value: SignUpForm[keyof SignUpForm]) => void;
   goToNextStep: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 }
 
-function StepContainerBase({
-  currentStep,
-  form,
-  handleChange,
-  goToNextStep,
-  formRef,
-  setIsFormValid,
-}: Readonly<Props>) {
+function StepContainerBase({ currentStep, form, handleChange, goToNextStep }: Readonly<Props>) {
   switch (currentStep) {
     case "이름 입력":
       return (
@@ -32,19 +23,11 @@ function StepContainerBase({
           value={form.name}
           onSubmit={(value) => handleChange("name", value)}
           onNext={goToNextStep}
-          formRef={formRef}
-          setIsFormValid={setIsFormValid}
         />
       );
     case "성별 선택":
       return (
-        <SelectGenderStep
-          gender={form.gender}
-          handleChange={handleChange}
-          onNext={goToNextStep}
-          formRef={formRef}
-          setIsFormValid={setIsFormValid}
-        />
+        <SelectGenderStep gender={form.gender} handleChange={handleChange} onNext={goToNextStep} />
       );
     case "생년월일 입력":
       return (
@@ -55,8 +38,6 @@ function StepContainerBase({
             handleChange("calendarType", value.calendarType);
           }}
           onNext={goToNextStep}
-          formRef={formRef}
-          setIsFormValid={setIsFormValid}
         />
       );
     case "출생시간 입력":
@@ -65,18 +46,10 @@ function StepContainerBase({
           value={form.birthTime}
           onSubmit={(value) => handleChange("birthTime", value)}
           onNext={goToNextStep}
-          formRef={formRef}
-          setIsFormValid={setIsFormValid}
         />
       );
     case "MBTI 입력":
-      return (
-        <SelectMbtiStep
-          handleChange={handleChange}
-          formRef={formRef}
-          setIsFormValid={setIsFormValid}
-        />
-      );
+      return <SelectMbtiStep handleChange={handleChange} />;
     default:
       return null;
   }

--- a/src/components/shared/sign-up-step/step-container.tsx
+++ b/src/components/shared/sign-up-step/step-container.tsx
@@ -8,12 +8,12 @@ import {
   TypeNameStep,
 } from "./step";
 
-interface Props {
+type Props = {
   currentStep: SignUpStep;
   form: SignUpForm;
   handleChange: (key: keyof SignUpForm, value: SignUpForm[keyof SignUpForm]) => void;
   goToNextStep: () => void;
-}
+};
 
 function StepContainerBase({ currentStep, form, handleChange, goToNextStep }: Readonly<Props>) {
   switch (currentStep) {

--- a/src/components/shared/sign-up-step/step/select-gender-step.tsx
+++ b/src/components/shared/sign-up-step/step/select-gender-step.tsx
@@ -1,4 +1,5 @@
 import { SelectButtons } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { Gender, SignUpForm } from "@/type";
 import React, { useEffect, useState } from "react";
 import styles from "./styles.module.scss";
@@ -7,17 +8,10 @@ interface Props {
   gender: Gender | undefined;
   handleChange: (key: keyof SignUpForm, value: Gender | undefined) => void;
   onNext: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 }
 
-export function SelectGenderStep({
-  gender,
-  handleChange,
-  onNext,
-  formRef,
-  setIsFormValid,
-}: Readonly<Props>) {
+export function SelectGenderStep({ gender, handleChange, onNext }: Readonly<Props>) {
+  const { currentStepFormRef, setIsFormValid } = useFormContext();
   const [selectedGender, setSelectedGender] = useState<Gender | undefined>(gender);
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -33,7 +27,7 @@ export function SelectGenderStep({
   }, [selectedGender, setIsFormValid]);
 
   return (
-    <form ref={formRef} className={styles.container} onSubmit={onSubmit}>
+    <form ref={currentStepFormRef} className={styles.container} onSubmit={onSubmit}>
       <SelectButtons
         select1Value="여자"
         select2Value="남자"

--- a/src/components/shared/sign-up-step/step/select-gender-step.tsx
+++ b/src/components/shared/sign-up-step/step/select-gender-step.tsx
@@ -1,15 +1,23 @@
 import { SelectButtons } from "@/components/ui";
 import { Gender, SignUpForm } from "@/type";
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./styles.module.scss";
 
-type Props = {
+interface Props {
   gender: Gender | undefined;
   handleChange: (key: keyof SignUpForm, value: Gender | undefined) => void;
   onNext: () => void;
-};
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
+}
 
-export function SelectGenderStep({ gender, handleChange, onNext }: Readonly<Props>) {
+export function SelectGenderStep({
+  gender,
+  handleChange,
+  onNext,
+  formRef,
+  setIsFormValid,
+}: Readonly<Props>) {
   const [selectedGender, setSelectedGender] = useState<Gender | undefined>(gender);
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -20,8 +28,12 @@ export function SelectGenderStep({ gender, handleChange, onNext }: Readonly<Prop
     onNext();
   };
 
+  useEffect(() => {
+    setIsFormValid(!!selectedGender);
+  }, [selectedGender, setIsFormValid]);
+
   return (
-    <form id="성별 선택" className={styles.container} onSubmit={onSubmit}>
+    <form ref={formRef} className={styles.container} onSubmit={onSubmit}>
       <SelectButtons
         select1Value="여자"
         select2Value="남자"

--- a/src/components/shared/sign-up-step/step/select-gender-step.tsx
+++ b/src/components/shared/sign-up-step/step/select-gender-step.tsx
@@ -4,11 +4,11 @@ import { Gender, SignUpForm } from "@/type";
 import React, { useEffect, useState } from "react";
 import styles from "./styles.module.scss";
 
-interface Props {
+type Props = {
   gender: Gender | undefined;
   handleChange: (key: keyof SignUpForm, value: Gender | undefined) => void;
   onNext: () => void;
-}
+};
 
 export function SelectGenderStep({ gender, handleChange, onNext }: Readonly<Props>) {
   const { currentStepFormRef, setIsFormValid } = useFormContext();

--- a/src/components/shared/sign-up-step/step/select-mbti-step.tsx
+++ b/src/components/shared/sign-up-step/step/select-mbti-step.tsx
@@ -3,14 +3,16 @@
 import { SelectButtons } from "@/components/ui";
 import { MBTI_BUTTONS } from "@/lib/const";
 import { MbtiState, SignUpForm } from "@/type";
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./styles.module.scss";
 
 type Props = {
   handleChange: (key: keyof SignUpForm, value: string) => void;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
 };
 
-export function SelectMbtiStep({ handleChange }: Readonly<Props>) {
+export function SelectMbtiStep({ handleChange, formRef, setIsFormValid }: Readonly<Props>) {
   const [typeM, setTypeM] = useState<MbtiState>(undefined);
   const [typeB, setTypeB] = useState<MbtiState>(undefined);
   const [typeT, setTypeT] = useState<MbtiState>(undefined);
@@ -33,8 +35,12 @@ export function SelectMbtiStep({ handleChange }: Readonly<Props>) {
     handleChange("mbti", mbti);
   };
 
+  useEffect(() => {
+    setIsFormValid(!!typeM && !!typeB && !!typeT && !!typeI);
+  }, [typeM, typeB, typeT, typeI, setIsFormValid]);
+
   return (
-    <form id="MBTI 입력" className={styles["mbti-container"]} onSubmit={onSubmit}>
+    <form ref={formRef} className={styles["mbti-container"]} onSubmit={onSubmit}>
       {MBTI_BUTTONS.map((button) => {
         const [selected, setSelected] = mbtiStates[button.type];
         return (

--- a/src/components/shared/sign-up-step/step/select-mbti-step.tsx
+++ b/src/components/shared/sign-up-step/step/select-mbti-step.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SelectButtons } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { MBTI_BUTTONS } from "@/lib/const";
 import { MbtiState, SignUpForm } from "@/type";
 import React, { useEffect, useState } from "react";
@@ -8,11 +9,10 @@ import styles from "./styles.module.scss";
 
 type Props = {
   handleChange: (key: keyof SignUpForm, value: string) => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 };
 
-export function SelectMbtiStep({ handleChange, formRef, setIsFormValid }: Readonly<Props>) {
+export function SelectMbtiStep({ handleChange }: Readonly<Props>) {
+  const { currentStepFormRef, setIsFormValid } = useFormContext();
   const [typeM, setTypeM] = useState<MbtiState>(undefined);
   const [typeB, setTypeB] = useState<MbtiState>(undefined);
   const [typeT, setTypeT] = useState<MbtiState>(undefined);
@@ -40,7 +40,7 @@ export function SelectMbtiStep({ handleChange, formRef, setIsFormValid }: Readon
   }, [typeM, typeB, typeT, typeI, setIsFormValid]);
 
   return (
-    <form ref={formRef} className={styles["mbti-container"]} onSubmit={onSubmit}>
+    <form ref={currentStepFormRef} className={styles["mbti-container"]} onSubmit={onSubmit}>
       {MBTI_BUTTONS.map((button) => {
         const [selected, setSelected] = mbtiStates[button.type];
         return (

--- a/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
@@ -10,11 +10,11 @@ import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
-interface Props {
+type Props = {
   value: { date: string; calendarType: CalendarType };
   onSubmit: (value: { date: string; calendarType: CalendarType }) => void;
   onNext: () => void;
-}
+};
 
 type FormValues = {
   birthDate: string;

--- a/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { CheckButton, FormInput } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { ValidationSchema } from "@/lib/const";
 import { formatBirthDate } from "@/lib/utils";
 import { CalendarType } from "@/type";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
@@ -13,8 +14,6 @@ interface Props {
   value: { date: string; calendarType: CalendarType };
   onSubmit: (value: { date: string; calendarType: CalendarType }) => void;
   onNext: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 }
 
 type FormValues = {
@@ -22,13 +21,8 @@ type FormValues = {
   calendarType: CalendarType;
 };
 
-export function TypeBirthDateStep({
-  onSubmit,
-  value,
-  onNext,
-  formRef,
-  setIsFormValid,
-}: Readonly<Props>) {
+export function TypeBirthDateStep({ onSubmit, value, onNext }: Readonly<Props>) {
+  const { currentStepFormRef, setIsFormValid } = useFormContext();
   const {
     control,
     handleSubmit,
@@ -52,7 +46,7 @@ export function TypeBirthDateStep({
   });
 
   return (
-    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={currentStepFormRef} onSubmit={onFormSubmit} className={styles.container}>
       <div className={styles["input-container"]}>
         <Controller
           name="birthDate"

--- a/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-birth-date-step.tsx
@@ -5,25 +5,34 @@ import { ValidationSchema } from "@/lib/const";
 import { formatBirthDate } from "@/lib/utils";
 import { CalendarType } from "@/type";
 import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
-type Props = {
-  onSubmit: (value: { date: string; calendarType: CalendarType }) => void;
+interface Props {
   value: { date: string; calendarType: CalendarType };
+  onSubmit: (value: { date: string; calendarType: CalendarType }) => void;
   onNext: () => void;
-};
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
+}
 
 type FormValues = {
   birthDate: string;
   calendarType: CalendarType;
 };
 
-export function TypeBirthDateStep({ onSubmit, value, onNext }: Readonly<Props>) {
+export function TypeBirthDateStep({
+  onSubmit,
+  value,
+  onNext,
+  formRef,
+  setIsFormValid,
+}: Readonly<Props>) {
   const {
     control,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormValues>({
     defaultValues: {
       birthDate: value.date,
@@ -33,13 +42,17 @@ export function TypeBirthDateStep({ onSubmit, value, onNext }: Readonly<Props>) 
     mode: "onChange",
   });
 
+  useEffect(() => {
+    setIsFormValid(isValid);
+  }, [isValid, setIsFormValid]);
+
   const onFormSubmit = handleSubmit((data) => {
     onSubmit({ date: data.birthDate, calendarType: data.calendarType });
     onNext();
   });
 
   return (
-    <form id="생년월일 입력" onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
       <div className={styles["input-container"]}>
         <Controller
           name="birthDate"

--- a/src/components/shared/sign-up-step/step/type-birth-time-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-birth-time-step.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { CheckButton, FormInput } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { ValidationSchema } from "@/lib/const";
 import { formatBirthTime } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
@@ -12,21 +13,14 @@ type Props = {
   onSubmit: (value: string | undefined) => void;
   value: string | undefined;
   onNext: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 };
 
 type FormValues = {
   birthTime?: string;
 };
 
-export function TypeBirthTimeStep({
-  onSubmit,
-  value = undefined,
-  onNext,
-  formRef,
-  setIsFormValid,
-}: Readonly<Props>) {
+export function TypeBirthTimeStep({ onSubmit, value = undefined, onNext }: Readonly<Props>) {
+  const { currentStepFormRef, setIsFormValid } = useFormContext();
   const [isUnknownTime, setIsUnknownTime] = useState(false);
   const {
     control,
@@ -55,43 +49,36 @@ export function TypeBirthTimeStep({
   }, [isUnknownTime, isValid, setIsFormValid]);
 
   return (
-    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={currentStepFormRef} onSubmit={onFormSubmit} className={styles.container}>
       <div className={styles["input-container"]}>
         <Controller
           name="birthTime"
           control={control}
           render={({ field: { onChange, onBlur, value: fieldValue, ref, name } }) => (
-            <>
-              <FormInput
-                onChange={(e) => {
-                  const formatted = formatBirthTime(e.target.value);
-                  onChange(formatted);
-                }}
-                onBlur={onBlur}
-                value={fieldValue ?? ""}
-                ref={ref}
-                name={name}
-                placeholder="13:00"
-                error={!!errors.birthTime?.message}
-                disabled={isUnknownTime}
-              />
-              <div className={styles["calendar-toggle"]}>
-                <CheckButton
-                  isChecked={isUnknownTime}
-                  className={styles["toggle-button"]}
-                  onClick={() => {
-                    setIsUnknownTime(!isUnknownTime);
-                    if (!isUnknownTime) {
-                      setValue("birthTime", undefined);
-                    }
-                  }}
-                >
-                  태어난 시간 모름
-                </CheckButton>
-              </div>
-            </>
+            <FormInput
+              onChange={(e) => {
+                const formatted = formatBirthTime(e.target.value);
+                onChange(formatted);
+              }}
+              onBlur={onBlur}
+              value={fieldValue}
+              ref={ref}
+              name={name}
+              placeholder="12:00"
+              error={!!errors.birthTime?.message}
+              disabled={isUnknownTime}
+            />
           )}
         />
+        <CheckButton
+          isChecked={isUnknownTime}
+          onClick={() => {
+            setIsUnknownTime((prev) => !prev);
+            setValue("birthTime", "");
+          }}
+        >
+          태어난 시간 모름
+        </CheckButton>
       </div>
     </form>
   );

--- a/src/components/shared/sign-up-step/step/type-birth-time-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-birth-time-step.tsx
@@ -4,7 +4,7 @@ import { CheckButton, FormInput } from "@/components/ui";
 import { ValidationSchema } from "@/lib/const";
 import { formatBirthTime } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
@@ -12,24 +12,34 @@ type Props = {
   onSubmit: (value: string | undefined) => void;
   value: string | undefined;
   onNext: () => void;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
 };
 
 type FormValues = {
   birthTime?: string;
 };
 
-export function TypeBirthTimeStep({ onSubmit, value = undefined, onNext }: Readonly<Props>) {
+export function TypeBirthTimeStep({
+  onSubmit,
+  value = undefined,
+  onNext,
+  formRef,
+  setIsFormValid,
+}: Readonly<Props>) {
   const [isUnknownTime, setIsUnknownTime] = useState(false);
   const {
     control,
     handleSubmit,
     setValue,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormValues>({
     defaultValues: {
       birthTime: value,
     },
-    resolver: zodResolver(ValidationSchema.birthTimeStep),
+    resolver: zodResolver(
+      isUnknownTime ? ValidationSchema.unknownBirthTimeStep : ValidationSchema.birthTimeStep,
+    ),
     mode: "onChange",
   });
 
@@ -40,8 +50,12 @@ export function TypeBirthTimeStep({ onSubmit, value = undefined, onNext }: Reado
     onNext();
   });
 
+  useEffect(() => {
+    setIsFormValid(isUnknownTime ? true : isValid);
+  }, [isUnknownTime, isValid, setIsFormValid]);
+
   return (
-    <form id="출생시간 입력" onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
       <div className={styles["input-container"]}>
         <Controller
           name="birthTime"

--- a/src/components/shared/sign-up-step/step/type-name-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-name-step.tsx
@@ -1,7 +1,8 @@
 import { FormInput } from "@/components/ui";
+import { useFormContext } from "@/hooks";
 import { ValidationSchema } from "@/lib/const";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
@@ -9,21 +10,14 @@ type Props = {
   onSubmit: (value: string) => void;
   value: string;
   onNext: () => void;
-  formRef: React.RefObject<HTMLFormElement | null>;
-  setIsFormValid: (isValid: boolean) => void;
 };
 
 type FormValues = {
   name: string;
 };
 
-export function TypeNameStep({
-  onSubmit,
-  value,
-  onNext,
-  formRef,
-  setIsFormValid,
-}: Readonly<Props>) {
+export function TypeNameStep({ onSubmit, value, onNext }: Readonly<Props>) {
+  const { currentStepFormRef, setIsFormValid } = useFormContext();
   const {
     control,
     handleSubmit,
@@ -46,7 +40,7 @@ export function TypeNameStep({
   });
 
   return (
-    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={currentStepFormRef} onSubmit={onFormSubmit} className={styles.container}>
       <Controller
         name="name"
         control={control}

--- a/src/components/shared/sign-up-step/step/type-name-step.tsx
+++ b/src/components/shared/sign-up-step/step/type-name-step.tsx
@@ -1,6 +1,7 @@
-import { Button, FormInput } from "@/components/ui";
+import { FormInput } from "@/components/ui";
 import { ValidationSchema } from "@/lib/const";
 import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styles from "./styles.module.scss";
 
@@ -8,17 +9,25 @@ type Props = {
   onSubmit: (value: string) => void;
   value: string;
   onNext: () => void;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  setIsFormValid: (isValid: boolean) => void;
 };
 
 type FormValues = {
   name: string;
 };
 
-export function TypeNameStep({ onSubmit, value, onNext }: Readonly<Props>) {
+export function TypeNameStep({
+  onSubmit,
+  value,
+  onNext,
+  formRef,
+  setIsFormValid,
+}: Readonly<Props>) {
   const {
     control,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormValues>({
     defaultValues: {
       name: value,
@@ -27,13 +36,17 @@ export function TypeNameStep({ onSubmit, value, onNext }: Readonly<Props>) {
     mode: "onChange",
   });
 
+  useEffect(() => {
+    setIsFormValid(isValid);
+  }, [isValid, setIsFormValid]);
+
   const onFormSubmit = handleSubmit((data) => {
     onSubmit(data.name);
     onNext();
   });
 
   return (
-    <form id="이름 입력" onSubmit={onFormSubmit} className={styles.container}>
+    <form ref={formRef} onSubmit={onFormSubmit} className={styles.container}>
       <Controller
         name="name"
         control={control}
@@ -50,9 +63,6 @@ export function TypeNameStep({ onSubmit, value, onNext }: Readonly<Props>) {
           />
         )}
       />
-      <Button onClick={onFormSubmit} direction="bottom">
-        다음
-      </Button>
     </form>
   );
 }

--- a/src/components/ui/button/forward-button.tsx
+++ b/src/components/ui/button/forward-button.tsx
@@ -2,11 +2,12 @@ import styles from "./styles.module.scss";
 
 type Props = {
   onClick: () => void;
+  disabled?: boolean;
 };
 
-export function ForwardButton({ onClick }: Readonly<Props>) {
+export function ForwardButton({ onClick, disabled }: Readonly<Props>) {
   return (
-    <button type="button" className={styles.forward} onClick={onClick}>
+    <button type="button" className={styles.forward} onClick={onClick} disabled={disabled}>
       <h4 className={styles["no-margin"]}>다음</h4>
     </button>
   );

--- a/src/components/ui/button/styles.module.scss
+++ b/src/components/ui/button/styles.module.scss
@@ -112,6 +112,11 @@
   height: 44px;
   min-width: 44px;
   width: fit-content;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }
 
 .icon {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useForm";
+export * from "./useFormContext";
 export * from "./useFunnel";

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 type UseFormReturn<T extends Record<string, string | undefined>> = {
   form: T;
@@ -11,10 +11,12 @@ export const useForm = <T extends Record<string, string | undefined>>(
 ): UseFormReturn<T> => {
   const [form, setForm] = useState<T>(initialForm);
 
-  const handleChange = (key: keyof T, value: string | undefined) => {
-    setForm((prev) => ({ ...prev, [key]: value }));
-  };
-
+  const handleChange = useCallback(
+    (key: keyof T, value: string | undefined) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [setForm],
+  );
 
   return {
     form,

--- a/src/hooks/useFormContext.tsx
+++ b/src/hooks/useFormContext.tsx
@@ -1,0 +1,40 @@
+import {
+  createContext,
+  Dispatch,
+  PropsWithChildren,
+  RefObject,
+  SetStateAction,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+interface FormContextType {
+  currentStepFormRef: RefObject<HTMLFormElement | null>;
+  isFormValid: boolean;
+  setIsFormValid: Dispatch<SetStateAction<boolean>>;
+}
+
+const FormContext = createContext<FormContextType | undefined>(undefined);
+
+function FormProvider({ children }: Readonly<PropsWithChildren>) {
+  const currentStepFormRef = useRef<HTMLFormElement>(null);
+  const [isFormValid, setIsFormValid] = useState(false);
+
+  const value = useMemo(
+    () => ({ currentStepFormRef, isFormValid, setIsFormValid }),
+    [currentStepFormRef, isFormValid, setIsFormValid],
+  );
+  return <FormContext.Provider value={value}>{children}</FormContext.Provider>;
+}
+
+function useFormContext() {
+  const context = useContext(FormContext);
+  if (context === undefined) {
+    throw new Error("useFormContext must be used within a FormProvider");
+  }
+  return context;
+}
+
+export { FormProvider, useFormContext };

--- a/src/lib/const/validationSchema.ts
+++ b/src/lib/const/validationSchema.ts
@@ -26,15 +26,15 @@ export const ValidationSchema = {
     calendarType: z.enum(["양력", "음력"]),
   }),
   birthTimeStep: z.object({
-    birthTime: z.union([
-      z.undefined(),
-      z
-        .string()
-        .min(5, "시간을 입력해주세요")
-        .refine((time) => {
-          const [hours, minutes] = time.split(":").map(Number);
-          return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
-        }, "올바른 시간을 입력해주세요."),
-    ]),
+    birthTime: z
+      .string()
+      .min(5, "시간을 입력해주세요")
+      .refine((time) => {
+        const [hour, minute] = time.split(":").map(Number);
+        return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59;
+      }, "올바른 시간을 입력해주세요"),
+  }),
+  unknownBirthTimeStep: z.object({
+    birthTime: z.string().optional(),
   }),
 };

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,2 +1,2 @@
 export * from "./dateFormat";
-export * from "./submitIdForm";
+export * from "./submitRefForm";

--- a/src/lib/utils/submitIdForm.ts
+++ b/src/lib/utils/submitIdForm.ts
@@ -1,7 +1,8 @@
-export const submitIdForm = (formId: string) => {
-  const formElement = document.getElementById(formId) as HTMLFormElement;
-  if (formElement) {
-    formElement.requestSubmit();
+import React from "react";
+
+export const submitIdForm = (formRef: React.RefObject<HTMLFormElement | null>) => {
+  if (formRef?.current) {
+    formRef.current.requestSubmit();
   } else {
     throw new Error("Form element not found");
   }

--- a/src/lib/utils/submitRefForm.ts
+++ b/src/lib/utils/submitRefForm.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const submitIdForm = (formRef: React.RefObject<HTMLFormElement | null>) => {
+export const submitRefForm = (formRef: React.RefObject<HTMLFormElement | null>) => {
   if (formRef?.current) {
     formRef.current.requestSubmit();
   } else {


### PR DESCRIPTION
https://github.com/user-attachments/assets/46158902-71bd-4c21-954f-579b53b16b9f

## 🔄 변경 사항
<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->

- 상단 다음 버튼에 form validation에 따라 disable 처리하기 위해 /sign-up 에서 validation state 관리
- 기존에 formId로 formElement getElementByID로 잡아서 submit시키던 부분 ref로 개선
- isFormValid 변경으로 인한 최상단 리렌더링에서 stepContainer를 제외하기 위해 memoization 추가
- 태어난 시간 스텝에서 state와 zod resolver 두가지를 혼용해서 사용하던 복잡한 부분 개선

## 📎 변경한 이유

- 아무래도 DOM api 직접사용은 안티패턴으로 보입니다. ref로 개선했습니다.
- 1depth drilling정도는 전역상태 대신 응집도 높게 최상단 지역상태로 관리하는게 좋다 판단했습니다.
- useForm/handleChange 함수참조가 isFormValid변경으로 인한 리렌더링시 변경되어 useCallback으로 캐싱해서 stepContainer memo했습니다
- 기존에 zodResolver와 state 두가지 혼용때문에 하드코딩된 부분을 resolver 하나 더 선언해서 바꿔끼는 방식으로 개선했습니다.

## 📌 갑자기 든 생각
- 이거 이렇게까지 온몸비틀기로 최적화 하는게 의미 없고 그냥 전역상태관리 때려박아도 될거같습니다..  단일 폼인데 굳이 이렇게까지 최적화를 해야 하나 싶네요.. 살짝 현타오는 부분

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->

<!-- 관련 이슈 넘버를 작성하세요! pr merge 이후 해당 이슈는 자동으로 close 됩니다. ex) closes: #110 -->

closes: #28 

<!-- ## 체크리스트

- [ ] 크롬, 모바일, 사파리 브라우저 호환 여부
- [ ] 머지 이후 버전 태그 등록 (ex. `v2.x.y`)
  - `x`: API 변경이 수반되거나 새로운 기능이 개발되었을 때 변경
  - `y`: API 변경이 수반되지 않는 변경, 사소한 버그 수정이 있을 때 변경
  - Annotated tag로 버전에 해당하는 간단한 설명 첨부 -->
